### PR TITLE
Add PulpFree users/<id>/meetings endpoint

### DIFF
--- a/MM-PulpFree/CHANGELOG.md
+++ b/MM-PulpFree/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **0.0.1**
 
+- Add `users/\<userId\>/meetings` endpoint, returning metadata for a user's meetings
 - Introduced KnownError object
   - Used to distinguish between errors thrown in a try/catch block with multiple awaited calls that would otherwise all be caught in the main catch, throwing a generic (unknown) error to the FE.
   - TLDR: Enables better error communication for users.

--- a/MM-PulpFree/app/actions/index.js
+++ b/MM-PulpFree/app/actions/index.js
@@ -1,5 +1,6 @@
 const { signup, login } = require("./auth");
 const { schedule, start, connect, finish, end } = require("./meeting");
+const { meetings } = require("./user");
 
 module.exports = {
   auth: {
@@ -12,5 +13,8 @@ module.exports = {
     connect,
     finish,
     end
+  },
+  user: {
+    meetings
   }
 };

--- a/MM-PulpFree/app/actions/user.js
+++ b/MM-PulpFree/app/actions/user.js
@@ -1,0 +1,32 @@
+const axios = require("axios");
+const conf = require("../config/config");
+const ErrorCodes = require("../error/ErrorCodes");
+const KnownError = require("../error/KnownError");
+
+const meetings = async params => {
+  try {
+    const userId = params.userId;
+
+    const meetingMetas = await axios
+      .get(conf.koolaidDomain + `/users/${userId}/meetings`)
+      .catch(err => {
+        if (err.response && err.response.status == 404) {
+          throw new KnownError("Cannot find user", ErrorCodes.USER.NOT_FOUND);
+        } else {
+          throw err;
+        }
+      });
+
+    return meetingMetas.data;
+  } catch (e) {
+    if (e instanceof KnownError) {
+      throw e;
+    }
+    console.log(e);
+    throw new Error("Error fetching metadata, please try again later");
+  }
+};
+
+module.exports = {
+  meetings
+};

--- a/MM-PulpFree/app/error/ErrorCodes.js
+++ b/MM-PulpFree/app/error/ErrorCodes.js
@@ -3,6 +3,10 @@ const ErrorCodes = {
   AUTH: {
     EMAIL_NOT_FOUND: 1000,
     PASSWORD_INCORRECT: 1001
+  },
+  // User ERRORS (2000 - 2999):
+  USER: {
+    NOT_FOUND: 2000
   }
 };
 

--- a/MM-PulpFree/app/routes/index.js
+++ b/MM-PulpFree/app/routes/index.js
@@ -3,6 +3,7 @@ const app = (module.exports = require("express")());
 //ROUTES
 app.use("/auth", require("./auth"));
 app.use("/meeting", require("./meeting"));
+app.use("/users", require("./user"));
 
 //CATCH
 app.all("*", (req, res) => {

--- a/MM-PulpFree/app/routes/user.js
+++ b/MM-PulpFree/app/routes/user.js
@@ -1,0 +1,19 @@
+const app = (module.exports = require("express")());
+
+const KnownError = require("../error/KnownError");
+const { meetings } = require("../actions").user;
+
+app.get("/:userId/meetings", (req, res) => {
+  meetings(req.params)
+    .then(meetingMetas => {
+      res.send({
+        meetingMetas
+      });
+    })
+    .catch(err => {
+      if (err instanceof KnownError) {
+        res.status(401).send(err.message);
+      }
+      res.status(500).send(err.message); // TODO do not expose stack trace
+    });
+});

--- a/MM-PulpFree/package-lock.json
+++ b/MM-PulpFree/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pulpfree",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Issue: https://github.com/ErisMik/Minutes-Made/issues/54

Add the `/users/<userId>/meetings` endpoint to PF, and the associated endpoint to KA.

Retrieves the meeting metadata for a user. Currently only the following fields from the `meetings` table:
`meetingid, starttime, endtime, active, scheduledstarttime, scheduledendtime`

![Screen Shot 2019-04-13 at 4 59 54 PM](https://user-images.githubusercontent.com/26511081/56085432-2cc3df80-5e11-11e9-8492-6433e534a192.png)
![Screen Shot 2019-04-13 at 4 55 29 PM](https://user-images.githubusercontent.com/26511081/56085433-2cc3df80-5e11-11e9-8fe5-e8a59420032e.png)
