### PR TITLE
Removed Undefined Reference

### DIFF
--- a/MM-PulpFree/app/actions/meeting.js
+++ b/MM-PulpFree/app/actions/meeting.js
@@ -220,6 +220,5 @@ module.exports = {
   schedule,
   start,
   connect,
-  finish,
-  end
+  finish
 };


### PR DESCRIPTION
`make run` results in the error:

`/home/hyao/Minutes-Made/MM-PulpFree/app/actions/meeting.js:224
  end
  ^

ReferenceError: end is not defined
    at Object.<anonymous> (/home/hyao/Minutes-Made/MM-PulpFree/app/actions/meeting.js:224:3)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/hyao/Minutes-Made/MM-PulpFree/app/actions/index.js:2:51)
    at Module._compile (module.js:652:30)
makefile:2: recipe for target 'run' failed
make: *** [run] Error 1
`
Unsure if we need this variable, but I removed it to get the build running. @ErisMik can you confirm if this is needed?